### PR TITLE
Fixes undefined method from DefaultLogWriter

### DIFF
--- a/src/DefaultLogWriter.php
+++ b/src/DefaultLogWriter.php
@@ -17,7 +17,7 @@ class DefaultLogWriter implements LogWriter
         $bodyAsJson = json_encode($request->except(config('http-logger.except')));
 
         $files = array_map(function (UploadedFile $file) {
-            return $file->path();
+            return $file->getRealPath();
         }, iterator_to_array($request->files));
 
         $message = "{$method} {$uri} - Body: {$bodyAsJson} - Files: ".implode(', ', $files);

--- a/src/DefaultLogWriter.php
+++ b/src/DefaultLogWriter.php
@@ -17,7 +17,7 @@ class DefaultLogWriter implements LogWriter
         $bodyAsJson = json_encode($request->except(config('http-logger.except')));
 
         $files = array_map(function (UploadedFile $file) {
-            return $file->getRealPath();
+            return $file->getClientOriginalName();
         }, iterator_to_array($request->files));
 
         $message = "{$method} {$uri} - Body: {$bodyAsJson} - Files: ".implode(', ', $files);

--- a/tests/DefaultLogWriterTest.php
+++ b/tests/DefaultLogWriterTest.php
@@ -77,7 +77,7 @@ class DefaultLogWriterTest extends TestCase
         $this->logger->logRequest($request);
 
         $log = $this->readLogFile();
-
+        
         $this->assertContains('test.md', $log);
     }
 }


### PR DESCRIPTION
Fixes `Call to undefined method Symfony\Component\HttpFoundation\File\UploadedFile::path()` error .from `DefaultLogWriter.php`, happening when an image is uploaded from a form in a `PUT` mode, for example.