### PR TITLE
Add the support for arrays with files in a request

### DIFF
--- a/src/DefaultLogWriter.php
+++ b/src/DefaultLogWriter.php
@@ -3,6 +3,7 @@
 namespace Spatie\HttpLogger;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -16,12 +17,24 @@ class DefaultLogWriter implements LogWriter
 
         $bodyAsJson = json_encode($request->except(config('http-logger.except')));
 
-        $files = array_map(function (UploadedFile $file) {
-            return $file->getClientOriginalName();
-        }, iterator_to_array($request->files));
-
-        $message = "{$method} {$uri} - Body: {$bodyAsJson} - Files: ".implode(', ', $files);
+        $files = (new Collection(iterator_to_array($request->files)))
+            ->map([$this, 'flatFiles'])
+            ->flatten()
+            ->implode(',')
+        ;
+        $message = "{$method} {$uri} - Body: {$bodyAsJson} - Files: ". $files;
 
         Log::info($message);
+    }
+
+    public function flatFiles($file)
+    {
+        if ($file instanceof UploadedFile) {
+            return $file->getClientOriginalName();
+        }
+        if (is_array($file)) {
+            return array_map([$this, 'flatFiles'], $file);
+        }
+        return (string) $file;
     }
 }

--- a/tests/DefaultLogWriterTest.php
+++ b/tests/DefaultLogWriterTest.php
@@ -80,4 +80,22 @@ class DefaultLogWriterTest extends TestCase
 
         $this->assertStringContainsString('test.md', $log);
     }
+
+    /** @test */
+    public function it_logs_files_in_an_array()
+    {
+        $file = $this->getTempFile();
+
+        $request = $this->makeRequest('post', $this->uri, [], [], [
+            'files' => [
+                new UploadedFile($file, 'test.md')
+            ],
+        ]);
+
+        $this->logger->logRequest($request);
+
+        $log = $this->readLogFile();
+
+        $this->assertStringContainsString('test.md', $log);
+    }
 }


### PR DESCRIPTION
I received errors with file uploads in an array (input name like files[] )  
This PR allow the handling of this arrays.

The only question I have is the last return (string) $file; I'm not sure that is reachable in a real situation.