### PR TITLE
Option to log fixed string to message and log request to context

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ return [
     'log_level' => 'info',
     
     /*
+     * A fixed string for the log message. If not null the request information is logged to the context.
+     */
+    'log_message' => null,
+    
+    /*
      * Filter out body fields which will never be logged.
      */
     'except' => [

--- a/config/http-logger.php
+++ b/config/http-logger.php
@@ -25,6 +25,11 @@ return [
     'log_level' => 'info',
 
     /*
+     * A fixed string for the log message. If not null the request information is logged to the context.
+     */
+    'log_message' => null,
+
+    /*
      * Filter out body fields which will never be logged.
      */
     'except' => [

--- a/tests/DefaultLogWriterTest.php
+++ b/tests/DefaultLogWriterTest.php
@@ -149,4 +149,19 @@ class DefaultLogWriterTest extends TestCase
         $this->assertStringContainsString('testing.DEBUG', $log);
         $this->assertStringContainsString('"name":"Name', $log);
     }
+
+    /** @test */
+    public function it_logs_the_configured_message()
+    {
+        $message = 'Test Message';
+        config(['http-logger.log_message' => $message]);
+        $request = $this->makeRequest('post', $this->uri);
+
+        $this->logger->logRequest($request);
+
+        $log = $this->readLogFile();
+
+        $this->assertStringContainsString($message, $log);
+    }
+
 }

--- a/tests/DefaultLogWriterTest.php
+++ b/tests/DefaultLogWriterTest.php
@@ -164,4 +164,21 @@ class DefaultLogWriterTest extends TestCase
         $this->assertStringContainsString($message, $log);
     }
 
+    /** @test */
+    public function it_logs_the_request_to_context()
+    {
+        $message = 'Test Message';
+        config(['http-logger.log_message' => $message]);
+        $request = $this->makeRequest('post', $this->uri, [
+            'name' => 'Name',
+        ]);
+
+        $this->logger->logRequest($request);
+
+        $log = $this->readLogFile();
+
+        $this->assertStringContainsString($message, $log);
+        $this->assertStringContainsString('"method":"POST"', $log);
+        $this->assertStringContainsString('"body":{"name":"Name"}', $log);
+    }
 }


### PR DESCRIPTION
As the context seems the perfect place to store structured information like the request I added a config option to fill the message with a fixed string an log the request to the log entry's context.
Default behavior is unchanged.