### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest,]
-                php: [8.1, 8.0, 7.4]
+                php: [8.2, 8.1, 8.0, 7.4]
                 laravel: [8.*, 9.*]
                 dependency-version: [prefer-stable]
                 include:
@@ -36,7 +36,7 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests


### PR DESCRIPTION
# Summary

This PR adds PHP 8.2 to the tests workflow.


_id:php82-support/v1_