### PR TITLE
Feature for Excluding HTTP Headers

### DIFF
--- a/config/http-logger.php
+++ b/config/http-logger.php
@@ -32,4 +32,11 @@ return [
         'password_confirmation',
     ],
 
+    /*
+     * Filter out header fields which will never be logged.
+     */
+    'except_headers' => [
+        'Authorization',
+    ],
+
 ];

--- a/src/DefaultLogWriter.php
+++ b/src/DefaultLogWriter.php
@@ -22,11 +22,18 @@ class DefaultLogWriter implements LogWriter
             ->map([$this, 'flatFiles'])
             ->flatten();
 
+        $headers = $request->headers->all();
+
+        // Remove any excluded headers from the headers array
+        foreach (config('http-logger.except_headers', []) as $header) {
+            unset($headers[$header]);
+        }
+
         return [
             'method' => strtoupper($request->getMethod()),
             'uri' => $request->getPathInfo(),
             'body' => $request->except(config('http-logger.except')),
-            'headers' => $request->headers->all(),
+            'headers' => $headers,
             'files' => $files,
         ];
     }

--- a/tests/DefaultLogWriterTest.php
+++ b/tests/DefaultLogWriterTest.php
@@ -53,6 +53,20 @@ it('will not log excluded fields', function () {
     assertStringNotContainsString('password_confirmation', $log);
 });
 
+it('logs headers except those in except_headers config', function () {
+    $request = $this->makeRequest('post', $this->uri, [
+        'name' => 'Name',
+    ]);
+
+    config(['http-logger.except_headers' => ['Authorization']]);
+    $this->logger->logRequest($request);
+
+    $log = $this->readLogFile();
+
+    assertStringContainsString('"name":"Name"', $log);
+    assertStringNotContainsString('Authorization', $log);
+});
+
 it('logs files', function () {
     $file = $this->getTempFile();
 
@@ -72,7 +86,7 @@ it('logs one file in an array', function () {
 
     $request = $this->makeRequest('post', $this->uri, [], [], [
         'files' => [
-        new UploadedFile($file, 'test.md'),
+            new UploadedFile($file, 'test.md'),
         ],
     ]);
 
@@ -88,8 +102,8 @@ it('logs multiple files in an array', function () {
 
     $request = $this->makeRequest('post', $this->uri, [], [], [
         'files' => [
-        new UploadedFile($file, 'first.doc'),
-        new UploadedFile($file, 'second.doc'),
+            new UploadedFile($file, 'first.doc'),
+            new UploadedFile($file, 'second.doc'),
         ],
     ]);
 


### PR DESCRIPTION
This feature is helpful if you do not want to log sensitive headers.

You just need to add those headers in

'except_headers' => [
        'Authorization',
],