### PR TITLE
Add option to sanitize sensitive headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,25 @@ public function logRequest(Request $request): void
 }
 ```
 
+#### Hide sensitive headers
+
+You can define headers that you want to sanitize before sending them to the log. 
+The most common example would be Authorization header. If you don't want to log jwt token, you can add that header to `http-logger.php` config file:
+
+```php
+// in config/http-logger.php
+
+return [
+    // ...
+    
+    'sanitize_headers' => [
+        'Authorization'
+    ],
+];
+```
+
+Output would be `Authorization: "****"` instead of `Authorization: "Bearer {token}"`
+
 ### Testing
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ return [
         'password',
         'password_confirmation',
     ],
+    
+    /*
+     * List of headers that will be sanitized. For example Authorization, Cookie, Set-Cookie...
+     */
+    'sanitize_headers' => [],
 ];
 ```
 

--- a/config/http-logger.php
+++ b/config/http-logger.php
@@ -32,4 +32,8 @@ return [
         'password_confirmation',
     ],
 
+    /*
+     * List of headers that will be sanitized. For example Authorization, Cookie, Set-Cookie...
+     */
+    'sanitize_headers' => [],
 ];

--- a/src/DefaultLogWriter.php
+++ b/src/DefaultLogWriter.php
@@ -9,6 +9,8 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class DefaultLogWriter implements LogWriter
 {
+    protected $sanitizer;
+
     public function logRequest(Request $request)
     {
         $message = $this->formatMessage($this->getMessage($request));
@@ -26,7 +28,7 @@ class DefaultLogWriter implements LogWriter
             'method' => strtoupper($request->getMethod()),
             'uri' => $request->getPathInfo(),
             'body' => $request->except(config('http-logger.except')),
-            'headers' => $request->headers->all(),
+            'headers' => $this->getSanitizer()->clean($request->headers->all(), config('http-logger.sanitize_headers')),
             'files' => $files,
         ];
     }
@@ -50,5 +52,14 @@ class DefaultLogWriter implements LogWriter
         }
 
         return (string) $file;
+    }
+
+    protected function getSanitizer()
+    {
+        if (!$this->sanitizer instanceof Sanitizer) {
+            $this->sanitizer = new Sanitizer();
+        }
+
+        return $this->sanitizer;
     }
 }

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\HttpLogger;
+
+class Sanitizer
+{
+    protected string $mask;
+
+    public function __construct(string $mask = "****")
+    {
+        $this->mask = $mask;
+    }
+
+    public function clean(array $input, $keys)
+    {
+        $keys = (array) $keys;
+
+        if (count($keys) === 0) {
+            return $input;
+        }
+
+        $keys = array_map([$this, 'normalize'], $keys);
+
+        foreach ($input as $key => $value) {
+            $normalizedKey = $this->normalize($key);
+
+            if (in_array($normalizedKey, $keys)) {
+                $input[$key] = $this->mask;
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $input[$key] = $this->clean($value, $keys);
+            }
+        }
+
+        return $input;
+    }
+
+    public function normalize(string $string)
+    {
+        return strtolower($string);
+    }
+
+    public function setMask(string $mask)
+    {
+        $this->mask = $mask;
+    }
+}

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -25,7 +25,7 @@ class Sanitizer
             $normalizedKey = $this->normalize($key);
 
             if (in_array($normalizedKey, $keys)) {
-                $input[$key] = $this->mask;
+                $input[$key] = is_array($value) ? [$this->mask] : $this->mask;
 
                 continue;
             }

--- a/tests/DefaultLogWriterTest.php
+++ b/tests/DefaultLogWriterTest.php
@@ -127,3 +127,16 @@ it('logs using the configured log level', function () {
     assertStringContainsString('testing.DEBUG', $log);
     assertStringContainsString('"name":"Name', $log);
 });
+
+it('will sanitize sensitive headers', function () {
+    config(['http-logger.sanitize_headers' => ['Authorization']]);
+
+    $request = $this->makeRequest('post', $this->uri, [], [], [], ['HTTP_Authorization' => 'Bearer {token}', 'HTTP_Api-Version' => '2.4.12']);
+
+    $this->logger->logRequest($request);
+
+    $log = $this->readLogFile();
+
+    assertStringContainsString('"authorization":"****"', $log);
+    assertStringContainsString('"api-version":["2.4.12"]', $log);
+});

--- a/tests/DefaultLogWriterTest.php
+++ b/tests/DefaultLogWriterTest.php
@@ -137,6 +137,6 @@ it('will sanitize sensitive headers', function () {
 
     $log = $this->readLogFile();
 
-    assertStringContainsString('"authorization":"****"', $log);
+    assertStringContainsString('"authorization":["****"]', $log);
     assertStringContainsString('"api-version":["2.4.12"]', $log);
 });


### PR DESCRIPTION
This PR adds the possibility to sanitize some headers that shouldn't be stored in logs, especially if you are using some third-party logging driver. For example, most likely we don't want to send jwt tokens from the Authorization header, or some IP addresses, etc. Because of that, I added one more configuration field to define headers that should be sanitized before sending. 

I didn't want to add some headers in the configuration by default, because maybe it would be backward incompatible since it would be a change of existing behavior.

Let me know if you have any questions or suggestions. 😊 