### PR TITLE
Add ability to enable/disable HTTP Logging via .env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ This is the contents of the published config file:
 return [
 
     /*
+     * Determine if the http-logger middleware should be enabled.
+     */
+    'enabled' => env('HTTP_LOGGER_ENABLED', true),
+
+    /*
      * The log profile which determines whether a request should be logged.
      * It should implement `LogProfile`.
      */
@@ -115,6 +120,7 @@ and `LogWriter` class will write the request to a log.
 A default log implementation is added within this package. 
 It will only log `POST`, `PUT`, `PATCH`, and `DELETE` requests 
 and it will write to the default Laravel logger.
+Logging is enabled by default but can be toggled on or off via the `HTTP_LOGGER_ENABLED` variable in the `.env` file.
 
 You're free to implement your own log profile and/or log writer classes, 
 and configure it in `config/http-logger.php`.

--- a/config/http-logger.php
+++ b/config/http-logger.php
@@ -3,6 +3,11 @@
 return [
 
     /*
+     * Determine if the http-logger middleware should be enabled.
+     */
+    'enabled' => env('HTTP_LOGGER_ENABLED', true),
+
+    /*
      * The log profile which determines whether a request should be logged.
      * It should implement `LogProfile`.
      */

--- a/src/LogNonGetRequests.php
+++ b/src/LogNonGetRequests.php
@@ -8,6 +8,10 @@ class LogNonGetRequests implements LogProfile
 {
     public function shouldLogRequest(Request $request): bool
     {
+        if (! config('http-logger.enabled')) {
+            return false;
+        }
+
         return in_array(strtolower($request->method()), ['post', 'put', 'patch', 'delete']);
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,9 +1,18 @@
 <?php
 
+use function PHPUnit\Framework\assertFileDoesNotExist;
 use function PHPUnit\Framework\assertFileExists;
 
 it('logs an incoming request via the middleware', function () {
     $this->call('post', '/');
 
     assertFileExists($this->getLogFile());
+});
+
+it('doesnt log an incoming request when disabled', function () {
+    config(['http-logger.enabled' => false]);
+
+    $this->call('post', '/');
+
+    assertFileDoesNotExist($this->getLogFile());
 });

--- a/tests/LogNonGetRequestsTest.php
+++ b/tests/LogNonGetRequestsTest.php
@@ -21,3 +21,13 @@ it('doesnt log get head options trace', function () {
         $this->assertFalse($this->logProfile->shouldLogRequest($request), "{$method} should not be logged.");
     }
 });
+
+it('doesnt log when disabled', function () {
+    config(['http-logger.enabled' => false]);
+
+    foreach (['post', 'put', 'patch', 'delete'] as $method) {
+        $request = $this->makeRequest($method, $this->uri);
+
+        $this->assertFalse($this->logProfile->shouldLogRequest($request), "{$method} should not be logged.");
+    }
+});


### PR DESCRIPTION
This PR introduces the ability to enable or disable HTTP logging via a new `.env` variable, `HTTP_LOGGER_ENABLED`. 
The default `LogNonGetRequests` implementation now includes this check before logging requests, allowing users to easily toggle logging on or off based on their environment configuration.