### PR TITLE
Add support for the QUERY HTTP method

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,55 +12,20 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.4]
-        laravel: ['8.*', '9.*', '10.*', '11.*', '12.*', '13.*']
+        php: [8.5, 8.4, 8.3]
+        laravel: ['12.*', '13.*']
         dependency-version: [prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.*
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*
             testbench: 11.*
-        exclude:
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 10.*
-            php: 7.4
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 11.*
-            php: 8.0
-          - laravel: 11.*
-            php: 7.4
-          - laravel: 12.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.0
-          - laravel: 12.*
-            php: 7.4
-          - laravel: 13.*
-            php: 7.4
-          - laravel: 13.*
-            php: 8.0
-          - laravel: 13.*
-            php: 8.1
-          - laravel: 13.*
-            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ a `LogProfile` class will determine whether the request should be logged,
 and `LogWriter` class will write the request to a log. 
 
 A default log implementation is added within this package. 
-It will only log `POST`, `PUT`, `PATCH`, and `DELETE` requests 
+It will only log `POST`, `PUT`, `PATCH`, `DELETE`, and `QUERY` requests 
 and it will write to the default Laravel logger.
 Logging is enabled by default but can be toggled on or off via the `HTTP_LOGGER_ENABLED` variable in the `.env` file.
 
@@ -133,7 +133,7 @@ This interface requires you to implement `shouldLogRequest`.
 
 public function shouldLogRequest(Request $request): bool
 {
-   return in_array(strtolower($request->method()), ['post', 'put', 'patch', 'delete']);
+   return in_array(strtolower($request->method()), ['post', 'put', 'patch', 'delete', 'query']);
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
+        "php": "^8.3",
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^1.22|^2.34|^3.7|^4.0",
-        "phpunit/phpunit": "^9.0|^10.5|^11.5.3|^12.5.12"
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^4.0",
+        "phpunit/phpunit": "^12.5.30"
     },
     "autoload": {
         "psr-4": {

--- a/src/LogNonGetRequests.php
+++ b/src/LogNonGetRequests.php
@@ -12,6 +12,6 @@ class LogNonGetRequests implements LogProfile
             return false;
         }
 
-        return in_array(strtolower($request->method()), ['post', 'put', 'patch', 'delete']);
+        return in_array(strtolower($request->method()), ['post', 'put', 'patch', 'delete', 'query']);
     }
 }

--- a/tests/DefaultLogWriterTest.php
+++ b/tests/DefaultLogWriterTest.php
@@ -12,7 +12,7 @@ beforeEach(function () {
 });
 
 it('logs request method and uri', function () {
-    foreach (['post', 'put', 'patch', 'delete'] as $method) {
+    foreach (['post', 'put', 'patch', 'delete', 'query'] as $method) {
         $request = $this->makeRequest($method, $this->uri);
 
         $this->logger->logRequest($request);
@@ -24,6 +24,19 @@ it('logs request method and uri', function () {
     assertStringContainsString("PUT {$this->uri}", $log);
     assertStringContainsString("PATCH {$this->uri}", $log);
     assertStringContainsString("DELETE {$this->uri}", $log);
+    assertStringContainsString("QUERY {$this->uri}", $log);
+});
+
+it('will log the query body', function () {
+    $request = $this->makeRequest('query', $this->uri, [
+        'filter' => 'active',
+    ]);
+
+    $this->logger->logRequest($request);
+
+    $log = $this->readLogFile();
+
+    assertStringContainsString('"filter":"active"', $log);
 });
 
 it('will log the body', function () {

--- a/tests/LogNonGetRequestsTest.php
+++ b/tests/LogNonGetRequestsTest.php
@@ -6,8 +6,8 @@ beforeEach(function () {
     $this->logProfile = new LogNonGetRequests();
 });
 
-it('logs post patch put delete', function () {
-    foreach (['post', 'put', 'patch', 'delete'] as $method) {
+it('logs post patch put delete query', function () {
+    foreach (['post', 'put', 'patch', 'delete', 'query'] as $method) {
         $request = $this->makeRequest($method, $this->uri);
 
         $this->assertTrue($this->logProfile->shouldLogRequest($request), "{$method} should be logged.");
@@ -25,7 +25,7 @@ it('doesnt log get head options trace', function () {
 it('doesnt log when disabled', function () {
     config(['http-logger.enabled' => false]);
 
-    foreach (['post', 'put', 'patch', 'delete'] as $method) {
+    foreach (['post', 'put', 'patch', 'delete', 'query'] as $method) {
         $request = $this->makeRequest($method, $this->uri);
 
         $this->assertFalse($this->logProfile->shouldLogRequest($request), "{$method} should not be logged.");


### PR DESCRIPTION
Closes #70.

Laravel 13.19 added support for the [QUERY HTTP method](https://laravel-news.com/laravel-13-19-0), which carries its parameters in the request body like `POST`. Since QUERY requests contain user-submitted bodies worth capturing, `LogNonGetRequests` now logs them alongside `POST`, `PUT`, `PATCH`, and `DELETE`.

While here, the dev tooling moves to the latest Pest (v4), which requires PHP 8.3+ and PHPUnit 12. Support for versions Pest 4 can no longer run on is dropped: PHP < 8.3 and Laravel < 12 (Laravel 11's testbench conflicts with PHPUnit 12.6+).